### PR TITLE
feat: 리뷰 기능 구현

### DIFF
--- a/app/code/[id]/page.tsx
+++ b/app/code/[id]/page.tsx
@@ -1,12 +1,14 @@
+import ReviewListContainer from '@/app/review/containers/ReviewListContainer';
 import CodeSnippetDetailContainer from './CodeSnippetDetailContainer';
 
 export default function CodeSnippetDetailPage({ params }: { params: { id: string } }) {
   const { id } = params;
+  const codeId = parseInt(id, 10);
 
   return (
     <main>
       <CodeSnippetDetailContainer id={id} />
-      {/* <ReviewList snippetId={id} /> */}
+      <ReviewListContainer codeId={codeId} />
     </main>
   );
 }

--- a/app/review/components/ReviewList.tsx
+++ b/app/review/components/ReviewList.tsx
@@ -8,7 +8,7 @@ import { formatDate } from '@/utils/formatDate';
 interface ReviewListProps {
   reviews: ReviewView[];
   codeId: number;
-  onExpandClick: (reviewId: number) => void;
+  onExpandClick?: (reviewId: number) => void;
   parentId?: number | null;
   commentButton?: boolean;
 }

--- a/app/review/components/ReviewList.tsx
+++ b/app/review/components/ReviewList.tsx
@@ -1,0 +1,73 @@
+import { ReviewView } from '@/domain/entities/ReviewView';
+import ProfileImage from '@/app/components/ProfileImage';
+import ReviewCommentContainer from '../containers/ReviewCommentContainer';
+import { ThumbsUp, MessageSquare } from 'lucide-react';
+import ReviewFormContainer from '../containers/ReviewFormContainer';
+import { formatDate } from '@/utils/formatDate';
+
+interface ReviewListProps {
+  reviews: ReviewView[];
+  codeId: number;
+  onExpandClick: (reviewId: number) => void;
+  parentId?: number | null;
+  commentButton?: boolean;
+}
+
+const ReviewList = ({
+  reviews,
+  codeId,
+  onExpandClick,
+  parentId,
+  commentButton = false,
+}: ReviewListProps) => {
+  return (
+    <div className="space-y-4">
+      {reviews.map((review) => (
+        <div
+          key={review.id}
+          className="border p-4 rounded shadow-sm flex flex-col items-start gap-2 m-8"
+        >
+          <div className="flex flex-row items-center gap-2 mr-2">
+            {/* 프로필 이미지 */}
+            <ProfileImage
+              src={review.user.imageUrl || '/default-profile-image.png'}
+              alt={`${review.user.nickname}의 프로필 이미지`}
+              size={50}
+            />
+            <div className="flex flex-col">
+              {/* 닉네임 + 날짜 */}
+              <div className="flex flex-row text-sm text-gray-800 font-semibold">
+                {review.user.nickname}
+                {/* 유저 아이디 */}
+                <div className="ml-2 text-xs text-gray-500">랭크{/*{review.user.email}*/}</div>
+              </div>
+              <div className="text-xs text-gray-500"> {formatDate(review.createdAt)}</div>
+            </div>
+          </div>
+          {/* 본문 내용 */}
+          <p className="mt-2 text-sm text-gray-700 font-bold">{review.content}</p>
+          <div className="flex flex-row items-center gap-4 mt-2">
+            <ThumbsUp className="m-3 w-5 text-gray-500" />
+            <div className="ml-[-1rem] text-gray-500 font-bold">{review.counts.likes ?? 0}</div>
+            {commentButton && (
+              <MessageSquare
+                onClick={() => onExpandClick?.(review.id)}
+                className="w-5 text-gray-500text-gray-500"
+              ></MessageSquare>
+            )}
+            <div className="ml-[-2px] text-gray-500 font-bold">{review.counts.replies ?? 0}</div>
+          </div>
+          {/* 대댓글 렌더링 위치 */}
+          {parentId === review.id && (
+            <div className="w-full">
+              <ReviewCommentContainer codeId={codeId} parentId={review.id} />
+              <ReviewFormContainer codeId={codeId} parentId={review.id} />
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ReviewList;

--- a/app/review/containers/ReviewCommentContainer.tsx
+++ b/app/review/containers/ReviewCommentContainer.tsx
@@ -15,7 +15,7 @@ export default function ReviewCommentContainer({
     queryKey: ['comments', codeId, parentId],
     queryFn: async () => {
       const res = await fetch(
-        `http://localhost:3000/api/member/codes/${codeId}/reviews?parent_id=${parentId}`,
+        `${process.env.NEXT_PUBLIC_BASE_URL}/api/member/codes/${codeId}/reviews?parent_id=${parentId}`,
         { cache: 'no-store' }
       );
       if (!res.ok) {

--- a/app/review/containers/ReviewCommentContainer.tsx
+++ b/app/review/containers/ReviewCommentContainer.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import ReviewList from '../components/ReviewList';
+import { ReviewView } from '@/domain/entities/ReviewView';
+
+export default function ReviewCommentContainer({
+  codeId,
+  parentId,
+}: {
+  codeId: number;
+  parentId: number;
+}) {
+  const { data, isLoading, error } = useQuery<ReviewView[]>({
+    queryKey: ['comments', codeId, parentId],
+    queryFn: async () => {
+      const res = await fetch(
+        `http://localhost:3000/api/member/codes/${codeId}/reviews?parent_id=${parentId}`,
+        { cache: 'no-store' }
+      );
+      if (!res.ok) throw new Error('답글 로딩 실패');
+      return res.json();
+    },
+  });
+
+  if (isLoading) return <div className="text-gray-500 ml-8">댓글 불러오는 중...</div>;
+  if (data?.length === 0) return;
+  if (error)
+    return (
+      <div className="text-gray-500 ml-8">댓글을 불러오지 못했습니다. 새로고침을 해주세요!</div>
+    );
+
+  return (
+    <div className="ml-6">
+      <ReviewList reviews={data!} codeId={codeId} onExpandClick={() => {}} />
+    </div>
+  );
+}

--- a/app/review/containers/ReviewCommentContainer.tsx
+++ b/app/review/containers/ReviewCommentContainer.tsx
@@ -18,21 +18,28 @@ export default function ReviewCommentContainer({
         `http://localhost:3000/api/member/codes/${codeId}/reviews?parent_id=${parentId}`,
         { cache: 'no-store' }
       );
-      if (!res.ok) throw new Error('답글 로딩 실패');
+      if (!res.ok) {
+        throw new Error('답글 로딩 실패');
+      }
       return res.json();
     },
   });
 
-  if (isLoading) return <div className="text-gray-500 ml-8">댓글 불러오는 중...</div>;
-  if (data?.length === 0) return;
-  if (error)
+  if (isLoading) {
+    return <div className="text-gray-500 ml-8">댓글 불러오는 중...</div>;
+  }
+  if (data?.length === 0) {
+    return;
+  }
+  if (error) {
     return (
       <div className="text-gray-500 ml-8">댓글을 불러오지 못했습니다. 새로고침을 해주세요!</div>
     );
+  }
 
   return (
     <div className="ml-6">
-      <ReviewList reviews={data!} codeId={codeId} onExpandClick={() => {}} />
+      <ReviewList reviews={data!} codeId={codeId} />
     </div>
   );
 }

--- a/app/review/containers/ReviewListClientContainer.tsx
+++ b/app/review/containers/ReviewListClientContainer.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useState } from 'react';
+import { ReviewView } from '@/domain/entities/ReviewView';
+import ReviewList from '../components/ReviewList';
+
+interface Props {
+  codeId: number;
+  reviews: ReviewView[];
+}
+
+export default function ReviewListClientContainer({ codeId, reviews }: Props) {
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  return (
+    <ReviewList
+      reviews={reviews}
+      codeId={codeId}
+      parentId={expandedId}
+      onExpandClick={(id) => setExpandedId((prev) => (prev === id ? null : id))}
+      commentButton
+    />
+  );
+}

--- a/app/review/containers/ReviewListContainer.tsx
+++ b/app/review/containers/ReviewListContainer.tsx
@@ -2,11 +2,16 @@ import { ReviewView } from '@/domain/entities/ReviewView';
 import ReviewListClientContainer from './ReviewListClientContainer';
 
 export default async function ReviewListContainer({ codeId }: { codeId: number }) {
-  const res = await fetch(`http://localhost:3000/api/member/codes/${codeId}/reviews`, {
-    cache: 'no-store',
-  });
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL}/api/member/codes/${codeId}/reviews`,
+    {
+      cache: 'no-store',
+    }
+  );
 
-  if (!res.ok) throw new Error('리뷰 데이터를 불러오지 못했습니다');
+  if (!res.ok) {
+    throw new Error('리뷰 데이터를 불러오지 못했습니다');
+  }
 
   const reviews: ReviewView[] = await res.json();
 

--- a/app/review/containers/ReviewListContainer.tsx
+++ b/app/review/containers/ReviewListContainer.tsx
@@ -1,0 +1,19 @@
+import { ReviewView } from '@/domain/entities/ReviewView';
+import ReviewListClientContainer from './ReviewListClientContainer';
+
+export default async function ReviewListContainer({ codeId }: { codeId: number }) {
+  const res = await fetch(`http://localhost:3000/api/member/codes/${codeId}/reviews`, {
+    cache: 'no-store',
+  });
+
+  if (!res.ok) throw new Error('리뷰 데이터를 불러오지 못했습니다');
+
+  const reviews: ReviewView[] = await res.json();
+
+  return (
+    <>
+      <h3 className="font-bold m-5">리뷰 목록 ({reviews.length})</h3>
+      <ReviewListClientContainer codeId={codeId} reviews={reviews} />
+    </>
+  );
+}


### PR DESCRIPTION
# Pull Request

## ➕ 이슈 번호

- [#12 ]

<br/>


## 📄 요약

리뷰 목록 및 대댓글 기능 구현
- SSR 방식으로 리뷰 목록 불러오기
- CSR 방식으로 대댓글 비동기 로딩 처리 (React Query 사용)
- 단순 UI 구성
- 
<br/>

##  PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

<br/>

## 👨‍🔧 변경사항
- ReviewListContainer에서 SSR 방식으로 전체 리뷰 데이터 fetch 및 전달
- ReviewListClientContainer에서 props로 받은 리뷰 데이터를 기반으로 UI 렌더링 및 확장 상태 관리
- ReviewCommentContainer에서 대댓글을 React Query를 사용해 CSR 방식으로 비동기 fetch
- 비동기 로딩/에러/빈 배열 처리 UI 적용
 
ReviewList: 리뷰 카드 UI 및 프로필/버튼/댓글 렌더링 구현
- 좋아요 및 댓글 아이콘 포함
- 유저 프로필 및 닉네임, 작성일, 내용 표시
- 대댓글 있을 시 하단에 댓글 및 작성 폼 노출

<br/>

## ➕ 이미지 첨부

![image](https://github.com/user-attachments/assets/8fc8c7ad-a9cd-41fa-9759-ab585a0c36ee)


<!--- UI 변경사항이 있는 경우 스크린샷이나 동영상을 첨부해주세요 -->

<br/>

## ✏️ 리뷰어
@DKULena @devGo20 

<br/>

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.

<br/>

## 📢 특이사항
- 로딩 되거나 리뷰 불러오지 못 할시 단순하게 문장으로 보여주고 있는데 따로 노는 느낌이라 변경해야 할 것 같습니다!
- 현재 ReviewList 내부에서 대댓글 로딩 및 작성폼이 포함되어 있어 컨테이너와 프리젠테이션 컴포넌트의 역할이 명확히 분리되지 않은 상태입니다. 유지보수성과 재사용성을 높이기 위해 대댓글 관련 UI(ReviewCommentContainer, ReviewFormContainer)를 별도의 컴포넌트로 추출하고, 상위 컨테이너에서 주입하는 방식으로 구조 개선이 필요합니다. 방법 추천 부탁드립니다!

<br/>

