### PR TITLE
Feat/shared component Header컴포넌트, 프론트 폴더 구조 개선

### DIFF
--- a/app/(member)/layout.tsx
+++ b/app/(member)/layout.tsx
@@ -3,11 +3,11 @@ import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
 
 export default async function MemberLayout({ children }: { children: React.ReactNode }) {
-  // const session = await getServerSession(authOptions);
+  const session = await getServerSession(authOptions);
 
-  // if (!session) {
-  //   redirect('/login');
-  // }
+  if (!session) {
+    redirect('/login');
+  }
 
   return <>{children}</>;
 }

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-// import { SignUpUseCase } from '@/application/user/SignUpUsecase';
 import { SignUpUseCase } from '@/application/usecases/auth/SignUpUsecase';
 import { PrUserRepository } from '@/infra/repositories/prisma/PrUserRepository';
 import { prisma } from '@/lib/prisma';

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { SignUpUseCase } from '@/application/user/SignUpUsecase';
+// import { SignUpUseCase } from '@/application/user/SignUpUsecase';
+import { SignUpUseCase } from '@/application/usecases/auth/SignUpUsecase';
 import { PrUserRepository } from '@/infra/repositories/prisma/PrUserRepository';
 import { prisma } from '@/lib/prisma';
 

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,50 +1,41 @@
+'use client';
+
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Code, PlusCircle } from 'lucide-react';
+import { PlusCircle } from 'lucide-react';
+import { useSession, signIn, signOut } from 'next-auth/react';
 
 export default function Header() {
-  // 로그인 상태 - 실제 구현에서는 인증 상태를 확인합니다
-  const isLoggedIn = false;
-  const user = {
-    name: '김개발',
-    avatar: '/placeholder.svg?height=40&width=40',
-  };
+  const { data: session, status } = useSession();
 
   return (
-    <header className="border-b bg-white">
-      <div className="container mx-auto flex h-16 items-center justify-between px-4">
-        <Link href="/" className="flex items-center gap-2">
-          <Code className="h-6 w-6 text-primary" />
-          <span className="text-lg font-bold">리뷰엉</span>
-        </Link>
-        <nav className="flex items-center gap-4">
-          <Link href="/code/create">
-            <Button variant="outline" size="sm" className="gap-1">
-              <PlusCircle className="h-4 w-4" />
-              코드 작성
-            </Button>
-          </Link>
+    <header className="border-b">
+      <div className="container mx-auto flex h-16 items-center justify-between">
+        <Link href="/">리뷰엉</Link>
 
-          {isLoggedIn ? (
-            <Link href="/mypage">
+        <nav>
+          {status === 'authenticated' ? (
+            <div className="flex items-center gap-4">
+              <Link href="/code/create">
+                <Button variant="outline" size="sm" className="gap-1">
+                  <PlusCircle className="h-4 w-4" />
+                  코드 작성
+                </Button>
+              </Link>
               <div className="flex items-center gap-2">
-                <Avatar className="h-8 w-8">
-                  <AvatarImage src={user.avatar || '/placeholder.svg'} alt={user.name} />
-                  <AvatarFallback>{user.name.slice(0, 2)}</AvatarFallback>
+                <Avatar>
+                  <AvatarImage src={session.user?.image || '/placeholder.svg'} />
+                  <AvatarFallback>{session.user?.name?.slice(0, 2) || '??'}</AvatarFallback>
                 </Avatar>
-                <span className="hidden md:inline">{user.name}</span>
+                <span>{session.user?.name || '사용자'}</span>
               </div>
-            </Link>
+              <Button onClick={() => signOut()}>로그아웃</Button>
+            </div>
           ) : (
-            <>
-              <Link href="/login">
-                <Button variant="ghost">로그인</Button>
-              </Link>
-              <Link href="/signup">
-                <Button>회원가입</Button>
-              </Link>
-            </>
+            <div className="flex items-center gap-2">
+              <Button onClick={() => signIn()}>로그인</Button>
+            </div>
           )}
         </nav>
       </div>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -2,9 +2,9 @@
 
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { PlusCircle } from 'lucide-react';
 import { useSession, signIn, signOut } from 'next-auth/react';
+import ProfileImage from './ProfileImage';
 
 export default function Header() {
   const { data: session, status } = useSession();
@@ -24,10 +24,11 @@ export default function Header() {
                 </Button>
               </Link>
               <div className="flex items-center gap-2">
-                <Avatar>
-                  <AvatarImage src={session.user?.image || '/placeholder.svg'} />
-                  <AvatarFallback>{session.user?.name?.slice(0, 2) || '??'}</AvatarFallback>
-                </Avatar>
+                <ProfileImage
+                  src={session.user?.image || '/default-profile-image.png'}
+                  alt={session.user?.name || '사용자'}
+                  size={32}
+                />
                 <span>{session.user?.name || '사용자'}</span>
               </div>
               <Button onClick={() => signOut()}>로그아웃</Button>

--- a/app/components/Provider.tsx
+++ b/app/components/Provider.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+
+export default function Provider({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,17 @@
-import Header from './components/Header';
 import QueryProvider from './components/QueryProvider';
+import Provider from './components/Provider';
+import Header from './components/Header';
 import './globals.css';
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
       <body>
         <QueryProvider>
-          <Header />
-          {children}
+          <Provider>
+            <Header />
+            {children}
+          </Provider>
         </QueryProvider>
       </body>
     </html>

--- a/app/login/components/LoginForm.tsx
+++ b/app/login/components/LoginForm.tsx
@@ -1,35 +1,45 @@
 'use client';
 
-import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Github, Mail } from 'lucide-react';
-import { useLogin } from '@/hooks/useLogin';
+import type { SocialLoginOptions } from '@/app/types/auth';
 
-export default function LoginForm() {
-  const { login, socialLogin, isLoading, error } = useLogin();
-  const [email, setEmail] = useState<string>('');
-  const [password, setPassword] = useState<string>('');
-
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    await login({ email, password });
+interface LoginFormProps {
+  formData: {
+    email: string;
+    password: string;
   };
+  isLoading: boolean;
+  error: string;
+  onSubmit: (e: React.FormEvent) => Promise<void>;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSocialLogin: (options: SocialLoginOptions) => Promise<void>;
+}
 
+export default function LoginForm({
+  formData,
+  isLoading,
+  error,
+  onSubmit,
+  onChange,
+  onSocialLogin,
+}: LoginFormProps) {
   return (
     <div className="grid gap-6">
-      <form onSubmit={handleLogin}>
+      <form onSubmit={onSubmit}>
         <div className="grid gap-4">
           <div className="grid gap-2">
             <Label htmlFor="email">이메일</Label>
             <Input
               id="email"
+              name="email"
               type="email"
               placeholder="user@email.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              value={formData.email}
+              onChange={onChange}
               required
               disabled={isLoading}
               className="bg-white"
@@ -44,10 +54,11 @@ export default function LoginForm() {
             </div>
             <Input
               id="password"
+              name="password"
               type="password"
               placeholder="••••••••"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              value={formData.password}
+              onChange={onChange}
               required
               disabled={isLoading}
               className="bg-white"
@@ -73,7 +84,7 @@ export default function LoginForm() {
           type="button"
           disabled={isLoading}
           className="bg-white"
-          onClick={() => socialLogin({ provider: 'github' })}
+          onClick={() => onSocialLogin({ provider: 'github' })}
         >
           <Github className="mr-2 h-4 w-4" />
           Github
@@ -83,7 +94,7 @@ export default function LoginForm() {
           type="button"
           disabled={isLoading}
           className="bg-white"
-          onClick={() => socialLogin({ provider: 'google' })}
+          onClick={() => onSocialLogin({ provider: 'google' })}
         >
           <Mail className="mr-2 h-4 w-4" />
           Google
@@ -92,3 +103,101 @@ export default function LoginForm() {
     </div>
   );
 }
+
+// {
+//   'use client';
+
+//   import { useState } from 'react';
+//   import { Button } from '@/components/ui/button';
+//   import { Input } from '@/components/ui/input';
+//   import { Label } from '@/components/ui/label';
+//   import { Separator } from '@/components/ui/separator';
+//   import { Github, Mail } from 'lucide-react';
+//   import { useLogin } from '@/hooks/useLogin';
+
+//   export default function LoginForm() {
+//     const { login, socialLogin, isLoading, error } = useLogin();
+//     const [email, setEmail] = useState<string>('');
+//     const [password, setPassword] = useState<string>('');
+
+//     const handleLogin = async (e: React.FormEvent) => {
+//       e.preventDefault();
+//       await login({ email, password });
+//     };
+
+//     return (
+//       <div className="grid gap-6">
+//         <form onSubmit={handleLogin}>
+//           <div className="grid gap-4">
+//             <div className="grid gap-2">
+//               <Label htmlFor="email">이메일</Label>
+//               <Input
+//                 id="email"
+//                 type="email"
+//                 placeholder="user@email.com"
+//                 value={email}
+//                 onChange={(e) => setEmail(e.target.value)}
+//                 required
+//                 disabled={isLoading}
+//                 className="bg-white"
+//               />
+//             </div>
+//             <div className="grid gap-2">
+//               <div className="flex items-center justify-between">
+//                 <Label htmlFor="password">비밀번호</Label>
+//                 <a href="#" className="text-xs text-muted-foreground hover:text-primary">
+//                   비밀번호 찾기
+//                 </a>
+//               </div>
+//               <Input
+//                 id="password"
+//                 type="password"
+//                 placeholder="••••••••"
+//                 value={password}
+//                 onChange={(e) => setPassword(e.target.value)}
+//                 required
+//                 disabled={isLoading}
+//                 className="bg-white"
+//               />
+//             </div>
+//             <Button type="submit" disabled={isLoading} className="font-bold">
+//               {isLoading ? '로그인 중...' : '로그인'}
+//             </Button>
+//             {error && <p className="text-red-500">{error}</p>}
+//           </div>
+//         </form>
+//         <div className="relative">
+//           <div className="absolute inset-0 flex items-center">
+//             <Separator className="w-full" />
+//           </div>
+//           <div className="relative flex justify-center text-xs uppercase">
+//             <span className="bg-white px-2 text-muted-foreground">또는 다음으로 계속</span>
+//           </div>
+//         </div>
+//         <div className="grid grid-cols-2 gap-4">
+//           <Button
+//             variant="outline"
+//             type="button"
+//             disabled={isLoading}
+//             className="bg-white"
+//             onClick={() => socialLogin({ provider: 'github' })}
+//           >
+//             <Github className="mr-2 h-4 w-4" />
+//             Github
+//           </Button>
+//           <Button
+//             variant="outline"
+//             type="button"
+//             disabled={isLoading}
+//             className="bg-white"
+//             onClick={() => socialLogin({ provider: 'google' })}
+//           >
+//             <Mail className="mr-2 h-4 w-4" />
+//             Google
+//           </Button>
+//         </div>
+//       </div>
+//     );
+//   }
+
+// }

--- a/app/login/containers/LoginContainer.tsx
+++ b/app/login/containers/LoginContainer.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+import { useLogin } from '@/hooks/useLogin';
+import LoginForm from '@/app/login/components/LoginForm';
+
+export default function LoginContainer() {
+  const { login, socialLogin, isLoading, error } = useLogin();
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await login(formData);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+  };
+  return (
+    <LoginForm
+      formData={formData}
+      isLoading={isLoading}
+      error={error}
+      onSubmit={handleSubmit}
+      onChange={handleChange}
+      onSocialLogin={socialLogin}
+    />
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,4 @@
-import LoginForm from './components/LoginForm';
+import LoginContainer from '@/app/login/containers/LoginContainer';
 
 export default function Login() {
   return (
@@ -7,7 +7,7 @@ export default function Login() {
         <div className="flex flex-col space-y-2 text-center">
           <h1 className="text-2xl font-semibold tracking-tight">로그인</h1>
           <p className="text-sm text-muted-foreground">이메일과 비밀번호를 입력하여 로그인하세요</p>
-          <LoginForm />
+          <LoginContainer />
           <p className="px-8 text-sm text-muted-foreground">
             아직 계정이 없으신가요?{' '}
             <a href="/signup" className="underline underline-offset-4 hover:text-primary">

--- a/app/signup/components/Signup.tsx
+++ b/app/signup/components/Signup.tsx
@@ -1,113 +1,80 @@
-'use client';
-
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+import { Label } from '@radix-ui/react-label';
 import { Separator } from '@/components/ui/separator';
 import { Github, Mail } from 'lucide-react';
 
-export default function SignupForm() {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState('');
-  const [formData, setFormData] = useState({
-    email: '',
-    password: '',
-    nickname: '',
-  });
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsLoading(true);
-    setError('');
-
-    try {
-      const response = await fetch('/api/auth/signup', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || '회원가입 중 오류가 발생했습니다.');
-      }
-
-      router.push('/login?message=회원가입이 완료되었습니다. 로그인해주세요.');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : '회원가입 중 오류가 발생했습니다.');
-    } finally {
-      setIsLoading(false);
-    }
+interface SignupFormProps {
+  formData: {
+    email: string;
+    password: string;
+    nickname: string;
   };
+  isLoading: boolean;
+  error: string;
+  onSubmit: (e: React.FormEvent) => Promise<void>;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
-  };
-
+export default function SignupForm({
+  formData,
+  isLoading,
+  error,
+  onSubmit,
+  onChange,
+}: SignupFormProps) {
   return (
     <div className="grid gap-6">
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={onSubmit}>
         <div className="grid gap-4">
-          {error && <div className="rounded-md bg-red-50 p-4 text-sm text-red-600">{error}</div>}
-
           <div className="grid gap-2">
             <Label htmlFor="email">이메일</Label>
             <Input
               id="email"
               name="email"
               type="email"
-              required
+              placeholder="user@email.com"
               value={formData.email}
-              onChange={handleChange}
+              onChange={onChange}
+              required
               disabled={isLoading}
               className="bg-white"
             />
           </div>
-
           <div className="grid gap-2">
             <Label htmlFor="nickname">닉네임</Label>
             <Input
               id="nickname"
               name="nickname"
               type="text"
-              required
+              placeholder="닉네임을 입력하세요"
               value={formData.nickname}
-              onChange={handleChange}
+              onChange={onChange}
+              required
               disabled={isLoading}
               className="bg-white"
             />
           </div>
-
           <div className="grid gap-2">
             <Label htmlFor="password">비밀번호</Label>
             <Input
               id="password"
               name="password"
               type="password"
-              required
+              placeholder="••••••••"
               value={formData.password}
-              onChange={handleChange}
+              onChange={onChange}
+              required
               disabled={isLoading}
               className="bg-white"
             />
           </div>
-
-          <Button type="submit" className="w-full" disabled={isLoading}>
+          <Button type="submit" disabled={isLoading} className="font-bold">
             {isLoading ? '처리 중...' : '회원가입'}
           </Button>
+          {error && <p className="text-red-500">{error}</p>}
         </div>
       </form>
-
       <div className="relative">
         <div className="absolute inset-0 flex items-center">
           <Separator className="w-full" />
@@ -116,7 +83,6 @@ export default function SignupForm() {
           <span className="bg-white px-2 text-muted-foreground">또는 다음으로 계속</span>
         </div>
       </div>
-
       <div className="grid grid-cols-2 gap-4">
         <Button variant="outline" type="button" disabled={isLoading} className="bg-white">
           <Github className="mr-2 h-4 w-4" />
@@ -130,3 +96,131 @@ export default function SignupForm() {
     </div>
   );
 }
+
+// {
+// 'use client';
+
+// import { useState } from 'react';
+// import { useRouter } from 'next/navigation';
+// import { Button } from '@/components/ui/button';
+// import { Input } from '@/components/ui/input';
+// import { Label } from '@/components/ui/label';
+// import { Separator } from '@/components/ui/separator';
+// import { Github, Mail } from 'lucide-react';
+// import axios from 'axios';
+
+// export default function SignupForm() {
+//   const router = useRouter();
+//   const [isLoading, setIsLoading] = useState(false);
+//   const [error, setError] = useState('');
+//   const [formData, setFormData] = useState({
+//     email: '',
+//     password: '',
+//     nickname: '',
+//   });
+
+//   const handleSubmit = async (e: React.FormEvent) => {
+//     e.preventDefault();
+//     setIsLoading(true);
+//     setError('');
+
+//     try {
+//       await axios.post('/api/auth/signup', formData, {
+//         headers: {
+//           'Content-Type': 'application/json',
+//         },
+//       });
+
+//       router.push('/login?message=회원가입이 완료되었습니다. 로그인해주세요.');
+//     } catch (err) {
+//       setError(err instanceof Error ? err.message : '회원가입 중 오류가 발생했습니다.');
+//     } finally {
+//       setIsLoading(false);
+//     }
+//   };
+
+//   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+//     const { name, value } = e.target;
+//     setFormData((prev) => ({
+//       ...prev,
+//       [name]: value,
+//     }));
+//   };
+
+//   return (
+//     <div className="grid gap-6">
+//       <form onSubmit={handleSubmit}>
+//         <div className="grid gap-4">
+//           {error && <div className="rounded-md bg-red-50 p-4 text-sm text-red-600">{error}</div>}
+
+//           <div className="grid gap-2">
+//             <Label htmlFor="email">이메일</Label>
+//             <Input
+//               id="email"
+//               name="email"
+//               type="email"
+//               required
+//               value={formData.email}
+//               onChange={handleChange}
+//               disabled={isLoading}
+//               className="bg-white"
+//             />
+//           </div>
+
+//           <div className="grid gap-2">
+//             <Label htmlFor="nickname">닉네임</Label>
+//             <Input
+//               id="nickname"
+//               name="nickname"
+//               type="text"
+//               required
+//               value={formData.nickname}
+//               onChange={handleChange}
+//               disabled={isLoading}
+//               className="bg-white"
+//             />
+//           </div>
+
+//           <div className="grid gap-2">
+//             <Label htmlFor="password">비밀번호</Label>
+//             <Input
+//               id="password"
+//               name="password"
+//               type="password"
+//               required
+//               value={formData.password}
+//               onChange={handleChange}
+//               disabled={isLoading}
+//               className="bg-white"
+//             />
+//           </div>
+
+//           <Button type="submit" className="w-full" disabled={isLoading}>
+//             {isLoading ? '처리 중...' : '회원가입'}
+//           </Button>
+//         </div>
+//       </form>
+
+//       <div className="relative">
+//         <div className="absolute inset-0 flex items-center">
+//           <Separator className="w-full" />
+//         </div>
+//         <div className="relative flex justify-center text-xs uppercase">
+//           <span className="bg-white px-2 text-muted-foreground">또는 다음으로 계속</span>
+//         </div>
+//       </div>
+
+//       <div className="grid grid-cols-2 gap-4">
+//         <Button variant="outline" type="button" disabled={isLoading} className="bg-white">
+//           <Github className="mr-2 h-4 w-4" />
+//           Github
+//         </Button>
+//         <Button variant="outline" type="button" disabled={isLoading} className="bg-white">
+//           <Mail className="mr-2 h-4 w-4" />
+//           Google
+//         </Button>
+//       </div>
+//     </div>
+//   );
+// }
+// }

--- a/app/signup/containers/SignupContainer.tsx
+++ b/app/signup/containers/SignupContainer.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import axios from 'axios';
+import SignupForm from '../components/Signup';
+
+export default function SignupContainer() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+    nickname: '',
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError('');
+
+    try {
+      await axios.post('/api/auth/signup', formData, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      router.push('/login?message=회원가입이 완료되었습니다. 로그인해주세요.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '회원가입 중 오류가 발생했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+  };
+
+  return (
+    <SignupForm
+      formData={formData}
+      onChange={handleChange}
+      onSubmit={handleSubmit}
+      isLoading={isLoading}
+      error={error}
+    />
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,20 +1,20 @@
 import Link from 'next/link';
-import Signup from './components/Signup';
+import SignupContainer from './containers/SignupContainer';
 
 export default function SignupPage() {
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <div className="w-full max-w-md space-y-8 rounded-lg border p-6 shadow-lg">
+      <div className="w-full max-w-md p-6">
         <div className="text-center">
           <h2 className="text-2xl font-bold">회원가입</h2>
           <p className="mt-2 text-sm text-gray-600">
             이미 계정이 있으신가요?{' '}
-            <Link href="/login" className="text-blue-600 hover:underline">
+            <Link href="/login" className="underline underline-offset-4 hover:text-primary">
               로그인
             </Link>
           </p>
         </div>
-        <Signup />
+        <SignupContainer />
       </div>
     </div>
   );

--- a/application/dto/auth/SignUpDto.ts
+++ b/application/dto/auth/SignUpDto.ts
@@ -1,4 +1,4 @@
-export interface SignUpDTO {
+export interface SignUpDto {
   email: string;
   password: string;
   nickname: string;

--- a/application/usecases/auth/SignUpUsecase.ts
+++ b/application/usecases/auth/SignUpUsecase.ts
@@ -1,6 +1,5 @@
-import { UserRepository } from '../../domain/repositories/UserRepository';
-import { SignUpDto } from '../dto/SignUpDto';
-import type { User } from '@/prisma/generated/client';
+import { UserRepository } from '@/domain/repositories/UserRepository';
+import { SignUpDto } from '@/application/dto/auth/SignUpDto';
 import bcrypt from 'bcryptjs';
 
 export class SignUpUseCase {


### PR DESCRIPTION
## ➕ 이슈 번호

## 📄 요약
- 회원가입/로그인 페이지를 Presentational-Container 패턴으로 리팩토링
- 세션 Provider 및 공통 Header 컴포넌트 개선

## PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 버그 수정
- [x] UI/디자인 변경

## 👨‍🔧 변경사항
- 로그인/회원가입 컨테이너 분리
- 세션 Provider 컴포넌트 추가 및 적용
- Header에서 프로필 이미지, 로그인/로그아웃 버튼 통일
- SignupUseCase 경로 및 import 정리


## ✅ 캡처
![image](https://github.com/user-attachments/assets/7f33f1a4-07e4-4867-8798-4818ef55006b)

## 📢 특이사항
- 세션 관련 로직이 추가되어, 로그인/로그아웃 테스트가 필요합니다.