### PR TITLE
feat: 데일리 코드 중간 리팩토링 확인 #29

### DIFF
--- a/app/components/DailyChallengeCard.tsx
+++ b/app/components/DailyChallengeCard.tsx
@@ -22,7 +22,7 @@ export default async function DailyChallengeCard() {
               content={data.codeSnippet.content}
               author={data.codeSnippet.user.nickname}
               profileImage={data.codeSnippet.user.imageUrl}
-              categories={data.codeSnippet.category}
+              categories={data.codeSnippet.categories}
               isAuthor={false}
               date={formatDate(data.codeSnippet.createdAt)}
             />

--- a/app/containers/actions.ts
+++ b/app/containers/actions.ts
@@ -1,7 +1,16 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
 export async function fetchDailyChallenge() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/codes/daily`, {
-    cache: 'no-store',
-  });
+  const session = await getServerSession(authOptions);
+  const userId = session?.user?.id;
+  console.log('session', session);
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL}/api/codes/daily${userId ? `?userId=${userId}` : ''}`,
+    {
+      cache: 'no-store',
+    }
+  );
 
   if (!res.ok) {
     if (res.status === 401) {

--- a/domain/repositories/ReviewRepository.ts
+++ b/domain/repositories/ReviewRepository.ts
@@ -50,4 +50,11 @@ export interface ReviewRepository {
    * @returns 답글 목록
    */
   findAllByParentId(codeId: number): Promise<ReviewView[]>;
+
+  /**
+   * 데일리 챌린지 코드에 대한 최신 2개 리뷰 조회
+   * @param codeId - 코드 작성자 ID
+   * @returns 최신 리뷰 2개
+   */
+  findLatestTwoByCodeId(codeId: number): Promise<ReviewView[]>;
 }


### PR DESCRIPTION
# Pull Request

## ➕ 이슈 번호

- #29 ]

<br/>


## 📄 요약

작업사항 공유 드립니다.

- userId를 params(쿼리 파라미터)로 받아오도록 수정  
- 카테고리 변환 로직을 API 라우트에서 usecase(DTO 변환) 이동 관심사 분리를 강화
- 데일리 챌린지 코드에 대한 최신 2개 리뷰를 조회하는 메서드를 추가

<br/>

##  PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정

<br/>

## 👨‍🔧 변경사항

-  userId를 쿼리 파라미터로 받아오는 방식으로 API 라우트 및 클라이언트 코드 수정
- 카테고리 변환 로직을 usecase에서 처리하도록 리팩토링
- DailyChallengeCard의 props 필드명을 categories로 통일
- 데일리 챌린지 코드에 대한 최신 2개 리뷰 조회 기능 추가
<br/>

## ➕ 이미지 첨부

<!--- UI 변경사항이 있는 경우 스크린샷이나 동영상을 첨부해주세요 -->

<br/>

## ✏️ 리뷰어

@devGo20 @1juyoung 
<br/>

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 브랜치가 최신 상태의 메인 브랜치와 병합 가능합니다.

<br/>

## 📢 특이사항

- 기존에 라우트에서 처리하던 데이터 변환 로직이 usecase로 이동되어, 추후 유지보수 및 확장에 용이합니다.
- 프론트엔드와 백엔드 간 데이터 구조가 일관성 있게 맞춰졌습니다.

